### PR TITLE
Create symlink in udev folder to any *.rules file at robot repository…

### DIFF
--- a/install
+++ b/install
@@ -153,7 +153,7 @@ fi
 
 # Configure RC files
 echo "${section}Configuration files${reset}"
-source ${ROBOTIC_PATH}/compsys/setup/config/install
+./setup/config/install
 echo
 
 # Install ROS if requested

--- a/setup/config/install
+++ b/setup/config/install
@@ -22,6 +22,14 @@ for rcfile in "vimrc" "tmux.conf"; do
   fi
 done
 
+for file in ${ROBOTIC_PATH}/${ROBOT}/*.rules; do
+    if [[ ! -e /etc/udev/rules.d/${file} ]]; then
+        filename="${file##*/}"
+        echo "Adding udev symlink for ${filename}"
+        sudo ln -s ${file} /etc/udev/rules.d/${filename}
+    fi
+done
+
 if [[ ! -d ${HOME}/.vim/bundle/Vundle.vim ]]; then
   echo "Setting up vim bundles..."
   git clone https://github.com/gmarik/Vundle.vim.git ~/.vim/bundle/Vundle.vim


### PR DESCRIPTION
Implementation of issue #10 
Install of rc config files now adds symlink in udev rules to any .rules file at the root of the robot repository