### PR TITLE
Add enum34 as pip dependency

### DIFF
--- a/packages/pip
+++ b/packages/pip
@@ -2,3 +2,4 @@ numpy
 bitstring
 pysensors
 pyqtgraph
+enum34


### PR DESCRIPTION
Enum34 is a backport to python 2.7 of PEP 0435 which adds enums type to python