### PR TITLE
Revert "Add install of rosserial for kinetic"

### DIFF
--- a/setup/ros/install
+++ b/setup/ros/install
@@ -14,11 +14,7 @@ echo "Updating apt package list..."
 sudo apt-get -qq update
 
 echo "Installing ROS..."
-sudo apt-get -y install ros-kinetic-desktop-full \
-    ros-kinetic-rosserial \
-    ros-kinetic-rosserial-arduino \
-    ros-kinetic-rosserial-python \
-    python-rosinstall
+sudo apt-get -y install ros-kinetic-desktop-full python-rosinstall
 
 echo "Setting up ROS dependencies..."
 sudo rosdep init


### PR DESCRIPTION
This reverts commit 7eb172a290e65df2c05c3078a4af4dc4cc3abd47 in favour of robot-specific dependencies.

See [here](https://github.com/mcgill-robotics/compsys/commit/7eb172a290e65df2c05c3078a4af4dc4cc3abd47) for more discussion.