### PR TITLE
Fix shell detection bug

### DIFF
--- a/roboticrc
+++ b/roboticrc
@@ -3,14 +3,7 @@
 # Initialize McGill Robotics customizations, ROS setup and paths
 
 # Determine shell
-if [ -n "$BASH_VERSION" ]; then
-   SHELL_EXT="bash"
-elif [ -n "$ZSH_VERSION" ]; then
-   SHELL_EXT="zsh"
-else
-   echo 'Could not determine the shell'
-   exit 1
-fi
+SHELL_EXT="$(basename $(readlink /proc/$$/exe))"
 
 # Set CLOBBER option to properly source ROS on ZSH
 if [[ ${SHELL_EXT} = "zsh" ]]; then

--- a/roboticrc
+++ b/roboticrc
@@ -3,8 +3,14 @@
 # Initialize McGill Robotics customizations, ROS setup and paths
 
 # Determine shell
-_SHELL_PROCESS=$(ps -p $$ -oargs=)
-SHELL_EXT=${_SHELL_PROCESS##-}
+if [ -n "$BASH_VERSION" ]; then
+   SHELL_EXT="bash"
+elif [ -n "$ZSH_VERSION" ]; then
+   SHELL_EXT="zsh"
+else
+   echo 'Could not determine the shell'
+   exit 1
+fi
 
 # Set CLOBBER option to properly source ROS on ZSH
 if [[ ${SHELL_EXT} = "zsh" ]]; then


### PR DESCRIPTION
`$SHELL_EXT`is always set to an unintended value because `$(ps -p $$ -oargs=)` results in something along the lines of `bash ./roboticrc`, which is not intended (intended value is just `bash`). 
This issue may be the root of the problems in #24.