### PR TITLE
Change key server for ROS key

### DIFF
--- a/setup/ros/install
+++ b/setup/ros/install
@@ -7,8 +7,8 @@ sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu xenial main" \
   > /etc/apt/sources.list.d/ros-latest.list'
 
 echo "Getting ROS apt verification key..."
-sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net \
-  --recv-key 0xB01FA116
+sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 \
+  --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 echo "Updating apt package list..."
 sudo apt-get -qq update


### PR DESCRIPTION
Change the key server to a more reliable one. This is the key server used in the [install guide](http://wiki.ros.org/kinetic/Installation/Ubuntu) of the ROS wiki. This pull request fixes #32 (hopefully).