### PR TITLE
Fix pip3 default

### DIFF
--- a/update
+++ b/update
@@ -27,10 +27,12 @@ echo "Updating pip3 dependencies..."
 get_dependencies pip3 | xargs sudo -H pip3 install --upgrade > /dev/null || :
 
 echo "Updating pip2 dependencies..."
+# pip2 needs to be installed after pip3 in order to be set as default
 get_dependencies pip | xargs sudo -H pip2 install --upgrade > /dev/null || :
 
 if [[ $(pip --version) != $(pip2 --version) ]]; then
   echo "Found mismatch in default pip. Correcting..."
+  # This will set the default pip to pip2 as expected
   PIP_PATH=$(which pip)
   PIP2_PATH=$(which pip2)
   sudo rm -f ${PIP_PATH}

--- a/update
+++ b/update
@@ -29,6 +29,14 @@ get_dependencies pip3 | xargs sudo -H pip3 install --upgrade > /dev/null || :
 echo "Updating pip2 dependencies..."
 get_dependencies pip | xargs sudo -H pip2 install --upgrade > /dev/null || :
 
+if [[ $(pip --version) != $(pip2 --version) ]]; then
+  echo "Found mismatch in default pip. Correcting..."
+  PIP_PATH=$(which pip)
+  PIP2_PATH=$(which pip2)
+  sudo rm -f ${PIP_PATH}
+  sudo ln -s ${PIP2_PATH} ${PIP_PATH}
+fi
+
 if [[ -d ${HOME}/.vim/bundle/Vundle.vim ]]; then
   echo "Updating vim plugins..."
   vim +PluginInstall +qall

--- a/update
+++ b/update
@@ -23,11 +23,11 @@ get_dependencies apt | xargs sudo apt-get -qq install || :
 echo "Updating gem dependencies..."
 get_dependencies gem | xargs sudo gem install --conservative > /dev/null || :
 
-echo "Updating pip dependencies..."
-get_dependencies pip | xargs sudo -H pip install --upgrade > /dev/null || :
-
 echo "Updating pip3 dependencies..."
 get_dependencies pip3 | xargs sudo -H pip3 install --upgrade > /dev/null || :
+
+echo "Updating pip2 dependencies..."
+get_dependencies pip | xargs sudo -H pip2 install --upgrade > /dev/null || :
 
 if [[ -d ${HOME}/.vim/bundle/Vundle.vim ]]; then
   echo "Updating vim plugins..."


### PR DESCRIPTION
This fixes #37 

Previously, after install compsys, `pip` would link to `pip3` instead of `pip2`. This is due to the order pip is upgraded in the `update` script. Whoever is last will override the `pip` symlink.

This fix reorders the installation to prevent the issue, and verifies that such issue is no longer present. If it still is, it will correct it.

All previous users of compsys should rerun the `update` script manually and reinstall all python rosdeps as they were likely all installed with `pip3` instead of `pip2`. In other words, just run the following:

```bash
cd ${ROBOTIC_PATH}/compsys
./update
roscd
rosdep install --reinstall -y --from-paths src
```

This will ask for your password.