### PR TITLE
Add ipython dependency and remove bitstring

### DIFF
--- a/packages/pip
+++ b/packages/pip
@@ -1,6 +1,6 @@
 pip
 numpy
-bitstring
+ipython
 pysensors
 pyqtgraph
 enum34

--- a/packages/pip3
+++ b/packages/pip3
@@ -1,4 +1,4 @@
 pip
 numpy
-bitstring
+ipython
 pyqtgraph


### PR DESCRIPTION
`bitstring` was needed by auv's tritech-micron library ages ago, but that has since moved to `rosdep`. 