### PR TITLE
Fix sudo pip discrepancy instead of pip

### DIFF
--- a/update
+++ b/update
@@ -30,11 +30,11 @@ echo "Updating pip2 dependencies..."
 # pip2 needs to be installed after pip3 in order to be set as default
 get_dependencies pip | xargs sudo -H pip2 install --upgrade > /dev/null || :
 
-if [[ $(pip --version) != $(pip2 --version) ]]; then
+if [[ $(sudo -H pip --version) != $(sudo -H pip2 --version) ]]; then
   echo "Found mismatch in default pip. Correcting..."
   # This will set the default pip to pip2 as expected
-  PIP_PATH=$(which pip)
-  PIP2_PATH=$(which pip2)
+  PIP_PATH=$(sudo which pip)
+  PIP2_PATH=$(sudo which pip2)
   sudo rm -f ${PIP_PATH}
   sudo ln -s ${PIP2_PATH} ${PIP_PATH}
 fi


### PR DESCRIPTION
This fixes #42 where `virtualenv`s can overshadow `sudo`'s `pip`