### PR TITLE
Use apt tmuxinator

### DIFF
--- a/packages/apt
+++ b/packages/apt
@@ -3,10 +3,10 @@ python-pip
 python3-pip
 vim
 tmux
+tmuxinator
 mosh
 glances
 tig
-ruby
 colordiff
 libsensors4
 tree

--- a/packages/gem
+++ b/packages/gem
@@ -1,1 +1,0 @@
-tmuxinator

--- a/update
+++ b/update
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Update vim plugins and apt, gem and pip dependencies
+# Update vim plugins, and apt and pip dependencies
 
 #########################################
 # Get dependencies from /packages
@@ -16,12 +16,8 @@ function get_dependencies () {
 }
 
 echo "Updating apt dependencies..."
-# -qq implies -y
 sudo apt-get -qq update
 get_dependencies apt | xargs sudo apt-get -qq install || :
-
-echo "Updating gem dependencies..."
-get_dependencies gem | xargs sudo gem install --conservative > /dev/null || :
 
 echo "Updating pip3 dependencies..."
 get_dependencies pip3 | xargs sudo -H pip3 install --upgrade > /dev/null || :


### PR DESCRIPTION
`tmuxinator` is now available as a an `apt` package. This means we don't need `gem` anymore.