### PR TITLE
Add catkin_lint to pip dependencies

### DIFF
--- a/packages/pip
+++ b/packages/pip
@@ -5,3 +5,4 @@ pysensors
 pyqtgraph
 enum34
 catkin_tools
+catkin_lint


### PR DESCRIPTION
This adds the `catkin lint` verb to `catkin-tools`.