### PR TITLE
Use sed to change shell instead of chsh

### DIFF
--- a/setup/zsh/install
+++ b/setup/zsh/install
@@ -34,7 +34,8 @@ fi
 
 echo "Switching default login shell..."
 if [[ ${SHELL##*/} != "zsh" ]]; then
-  chsh -s $(which zsh)
+  sudo sed -i -e "s/${whoami}:\/bin\/bash/${whoami}:\/usr\/bin\/zsh/" \
+    /etc/passwd
 fi
 
 echo "Done."


### PR DESCRIPTION
To prevent prompting user to input password for chsh during installation