### PR TITLE
Add support for custom topics file and path in bag tool

### DIFF
--- a/roboticrc
+++ b/roboticrc
@@ -31,6 +31,9 @@ function rosworkon {
     # Reset ROBOT
     export ROBOT=${1}
 
+    # Reset TOPICS_PATH for bagging
+    export TOPICS_PATH=${ROBOTIC_PATH}/${ROBOT}/topics
+
     # Reset package path from previous workspace
     export ROS_PACKAGE_PATH=/opt/ros/kinetic/share
 

--- a/scripts/bag/README.md
+++ b/scripts/bag/README.md
@@ -86,8 +86,13 @@ bag --help
 ```
 
 ### 3. How do I configure my topics?
-This tool determines the topics to look from a `topics` file located in your
-project's root repository (i.e. `$ROBOTIC_PATH/$ROBOT/topics`).
+This tool determines the topics to look from a `topics` file located in
+`$TOPICS_PATH`. For convenience, `compsys` by default sets `$TOPIC_PATH`
+to `$ROBOTIC_PATH/$ROBOT/topics`. You may override the defaults as follows:
+
+```bash
+TOPICS_PATH=path/to/topics/file bag --help
+```
 
 The `topics` file is formatted like an `ini` file. It consists of a list of
 topic groups defined as such:

--- a/scripts/bag/run.py
+++ b/scripts/bag/run.py
@@ -15,20 +15,22 @@ recorded/merged if no arguments are specified. Otherwise, only the topics
 specified will be recorded/merged.
 """
 
+import os
 import sys
 from util import Parser, TopicList
 
 __author__ = "Anass Al-Wohoush"
-__version__ = "1.1"
+__version__ = "1.2.0"
 
 
 if __name__ == "__main__":
     try:
-        topics = TopicList().topics
+        topics_path = os.environ["TOPICS_PATH"]
     except KeyError:
-        print("E: ROBOTIC_PATH and/or ROBOT environment variables not set.")
-        print("did you install the 'compsys' package correctly?")
+        print("E: TOPICS_PATH environment variable not set")
         sys.exit(2)
+
+    topics = TopicList(topics_path)
 
     args = Parser(topics, __doc__, __version__)
     status = args.cmd(

--- a/scripts/bag/util/parser.py
+++ b/scripts/bag/util/parser.py
@@ -50,7 +50,7 @@ class Parser(object):
             version: Version of the executable.
         """
         self.arg = sys.argv[1:]
-        self.original = original
+        self.original = original.topics
         self.name = None
         self.description = description
         self.version = version
@@ -68,7 +68,7 @@ class Parser(object):
 
         parser.add_argument(
             "--version", action="version",
-            version="McGill Robotics' ROS Bagger {v}".format(v=self.version)
+            version="v{}".format(self.version)
         )
 
         # Add subparsers.

--- a/scripts/bag/util/topics.py
+++ b/scripts/bag/util/topics.py
@@ -41,17 +41,13 @@ class TopicList(object):
         topics: List of Topics parsed from 'topics' file.
     """
 
-    def __init__(self):
+    def __init__(self, path):
         """Construct TopicList object.
 
-        The topics configuration file should be placed in the root of the
-        project's git repository (i.e. ${ROBOTIC_PATH}/${ROBOT}/topics).
-
-        Raises:
-            KeyError: ROBOTIC_PATH and/or ROBOT environment variables not set.
+        Args:
+            path: Path to topics configuration file.
         """
-        robot = os.path.join(os.environ["ROBOTIC_PATH"], os.environ["ROBOT"])
-        self.filename = os.path.join(robot, "topics")
+        self.filename = path
         self.topics = []
 
         self._config = ConfigParser.ConfigParser()


### PR DESCRIPTION
The `bag` tool will now read from `$TOPICS_PATH` instead of `$ROBOTIC_PATH/$ROBOT/topics` for more customizability.

`compsys` now sets `$TOPICS_PATH` to `$ROBOTIC_PATH/$ROBOT/topics`, to remain backwards compatible. As such, this change should be non-breaking.