### PR TITLE
Exclude devel from ROS_PACKAGE_PATH

### DIFF
--- a/roboticrc
+++ b/roboticrc
@@ -46,7 +46,7 @@ function rosworkon {
 
     # Set environment variables
     export ROS_WORKSPACE=${repo_path}/catkin_ws
-    export ROS_PACKAGE_PATH=${ROS_PACKAGE_PATH}:${ROS_WORKSPACE}
+    export ROS_PACKAGE_PATH=${ROS_PACKAGE_PATH}:${ROS_WORKSPACE}/src
 
     # Source robot-specific configuration
     if [[ -f ${repo_path}/robotrc ]]; then


### PR DESCRIPTION
You are suppose to only add `src` folder of `$ROS_WORKSPACE` to `$ROS_PACKAGE_PATH`.
This affect how `rosdep` work. If this is merged, we only need `rosdep install -ai --skip-keys="..."` and dont have to play with `$ROS_PACKAGE_PATH` anymore.