### PR TITLE
Trap error for main install and add set -e for other installer script

### DIFF
--- a/install
+++ b/install
@@ -2,18 +2,23 @@
 #
 # Install the McGill Robotics CompSys package
 
-# Fail on first error
-set -e
-
-# Determine ROBOTIC_PATH
-export ROBOTIC_PATH=$(dirname ${PWD})
-
 # Colors
 header=$(tput setab 1; tput setaf 0)
 question=$(tput bold; tput setaf 4)
 section=$(tput bold; tput setaf 2)
 warning=$(tput bold; tput setaf 1)
 reset=$(tput sgr0)
+# Fail on first error
+set -e
+
+# Print err message when failed
+function onerr {
+echo "${warning}Script failed to compelete due to subprocess error...${reset}"
+}
+trap onerr ERR
+
+# Determine ROBOTIC_PATH
+export ROBOTIC_PATH=$(dirname ${PWD})
 
 # Verify running on Ubuntu 16.04
 if [[ $(lsb_release -sc) != "xenial" ]]; then

--- a/setup/config/install
+++ b/setup/config/install
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Set up shell, vim and tmux configuration files
+set -e
 
 for rcfile in "${HOME}/.bashrc" "${HOME}/.zshrc"; do
   if [[ -f ${rcfile} ]]; then

--- a/setup/ros/install
+++ b/setup/ros/install
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Install ROS Kinetic Kame on Ubuntu 16.04 LTS
+set -e
 
 echo "Adding ROS PPA..."
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu xenial main" \

--- a/setup/zsh/install
+++ b/setup/zsh/install
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Install Zsh and set up Prezto
+set -e
 
 echo "Installing zsh..."
 sudo apt-get -y -qq install zsh

--- a/update
+++ b/update
@@ -9,6 +9,7 @@
 # Returns:
 #   Space separated list of dependencies
 #########################################
+set -e
 
 section=$(tput bold; tput setaf 2)
 reset=$(tput sgr0)


### PR DESCRIPTION
This is to address concern in #34.

* Trap error for the main installer script to print error message when subprocess fails.
* Add `set -e` for all the installer script for they could be run as standalone scripts and should fail when their subprocess fails