### PR TITLE
Remove devel from ROS_PACKAGE_PATH

### DIFF
--- a/roboticrc
+++ b/roboticrc
@@ -36,6 +36,7 @@ function rosworkon {
     export ROBOT=${1}
     unset CATKIN_PROFILE
     repo_path=${ROBOTIC_PATH}/${ROBOT}
+
     # Reset package path from previous workspace
     export ROS_PACKAGE_PATH=/opt/ros/kinetic/share
 
@@ -46,7 +47,6 @@ function rosworkon {
 
     # Set environment variables
     export ROS_WORKSPACE=${repo_path}/catkin_ws
-    export ROS_PACKAGE_PATH=${ROS_PACKAGE_PATH}:${ROS_WORKSPACE}
 
     # Source robot-specific configuration
     if [[ -f ${repo_path}/robotrc ]]; then


### PR DESCRIPTION
`ROS_PACKAGE_PATH` only needs to be set to `/opt/ros/kinetic/share`. Neither `devel` nor `src` need be here. I confirmed that `rosdep` now works as expected and that we're able to `rosrun` and `roslaunch` after building and sourcing `devel/setup.bash` (the latter is done automatically by compsys).
