### PR TITLE
Pushd popd

### DIFF
--- a/install
+++ b/install
@@ -231,7 +231,9 @@ fi
 
 if [[ -f ${gitdir}/setup.sh ]]; then
   echo "Setting up robot dependencies..."
-  source ${gitdir}/setup.sh
+  pushd ${gitdir}
+  source setup.sh
+  popd
 fi
 
 # Clone bare repository for robot

--- a/roboticrc
+++ b/roboticrc
@@ -6,9 +6,13 @@ SHELL_EXT=$(
   ([ -n "${BASH_VERSION}" ] && echo bash)
 )
 
-# Set CLOBBER option to properly source ROS on ZSH
+# ZSH-specific settings
 if [[ ${SHELL_EXT} = "zsh" ]]; then
+  # Set CLOBBER option to properly source ROS
   setopt CLOBBER
+
+  # Allow for duplicate paths in the stack
+  unsetopt PUSHD_IGNORE_DUPS
 fi
 
 # Setup ROS


### PR DESCRIPTION
This partially addresses #74 
This fixes it for existing users but not for new users that are installing this for the first time, but who were previously using `zsh` with `PUSHD_IGNORE_DUPS` set. This is a very unlikely number of people as `compsys` is usually always install in `bash` the first time. This can be addressed by simply sourcing `roboticrc` instead of `/opt/ros/kinetic/setup.sh` directly, but apparently that causes issues.

@Baycken can you explain what the issues are exactly and if this fixes the problem you were having?