### PR TITLE
Fix unassigned variables

### DIFF
--- a/install
+++ b/install
@@ -210,7 +210,7 @@ fi
 echo "${section}Git${reset}"
 gitdir=${ROBOTIC_PATH}/${ROBOT}
 if [[ ! -d ${gitdir} ]]; then
-  echo "Cloning ${robot} git repository..."
+  echo "Cloning ${ROBOT} git repository..."
 
   if [[ ${GIT_BRANCH} ]]; then
     gitcmd="-b ${GIT_BRANCH}"

--- a/setup/zsh/install
+++ b/setup/zsh/install
@@ -41,7 +41,7 @@ fi
 
 echo "Switching default login shell..."
 if [[ ${SHELL##*/} != "zsh" ]]; then
-  sudo sed -i -e "s/${whoami}:\/bin\/bash/${whoami}:\/usr\/bin\/zsh/" \
+  sudo sed -i -e "s/$(whoami):\/bin\/bash/$(whoami):\/usr\/bin\/zsh/" \
     /etc/passwd
 fi
 


### PR DESCRIPTION
I am not too sure about replacing this:
```
sudo sed -i -e "s/${whoami}:\/bin\/bash/${whoami}:\/usr\/bin\/zsh/" \
     /etc/passwd`
```
with this:
```
sudo sed -i -e "s/$(whoami):\/bin\/bash/$(whoami):\/usr\/bin\/zsh/" \
     /etc/passwd`
```
Can someone confirm that it's correct?