### PR TITLE
Remove TivaWare references

### DIFF
--- a/roboticrc
+++ b/roboticrc
@@ -102,12 +102,6 @@ rosworkon ${ROBOT}
 # Add compsys scripts to PYTHONPATH
 export PYTHONPATH=${PYTHONPATH}:${ROBOTIC_PATH}/compsys/scripts
 
-# Add TivaWare path and lm4flash path
-if [[ -d ${ROBOTIC_PATH}/tivaware ]]; then
-  export TIVA_WARE_PATH=${ROBOTIC_PATH}/tivaware
-  export TIVA_FLASH_EXECUTABLE=lm4flash
-fi
-
 # Source custom aliases and functions
 source ${ROBOTIC_PATH}/compsys/aliases
 


### PR DESCRIPTION
`rover` is already dealing with this in their own `robotrc`, so removing this to fix #79 