### PR TITLE
Use sys.exit to exit script

### DIFF
--- a/scripts/bag/util/parser.py
+++ b/scripts/bag/util/parser.py
@@ -23,7 +23,7 @@ class Help(argparse.Action):
             option_string: Option string used to invole this action. Not used.
         """
         parser.print_help()
-        exit()
+        sys.exit()
 
 
 class Parser(object):


### PR DESCRIPTION
Use 'sys.exit' to exit script instead of 'exit'.
Yes, this change may just be pedantry. :neutral_face: