### PR TITLE
Enable the vim spell checker

### DIFF
--- a/setup/config/vimrc
+++ b/setup/config/vimrc
@@ -95,6 +95,10 @@ set wrap
 set colorcolumn=80
 set number
 
+" Spell checker
+set spell
+set spelllang=en
+
 " Colorscheme
 set t_Co=256
 if filereadable($HOME.'/.vim/bundle/vim-colorschemes/colors/gruvbox.vim')


### PR DESCRIPTION
This should make it easier to spot spelling mistakes in documentation.