### PR TITLE
Install pip using apt instead of pip

### DIFF
--- a/packages/apt
+++ b/packages/apt
@@ -14,7 +14,7 @@ tree
 libv4l-dev
 python-pygame
 pyqt4-dev-tools
-software-properties-common 
+software-properties-common
 python-software-properties
 curl
 clang-format

--- a/packages/pip
+++ b/packages/pip
@@ -1,4 +1,3 @@
-pip
 numpy
 ipython<6.0
 pysensors

--- a/packages/pip3
+++ b/packages/pip3
@@ -1,4 +1,3 @@
-pip
 numpy
 ipython
 pyqtgraph

--- a/update
+++ b/update
@@ -13,23 +13,11 @@ sudo apt-get -qq update
 # piping the contents of the requirements list into xargs.
 sed 's/#.*//' "${ROBOTIC_PATH}/compsys/packages/apt" | xargs sudo apt-get install -y
 
+echo "${section}Updating pip dependencies...${reset}"
+sudo -H pip install --upgrade --requirement "${ROBOTIC_PATH}/compsys/packages/pip"
+
 echo "${section}Updating pip3 dependencies...${reset}"
 sudo -H pip3 install --upgrade --requirement "${ROBOTIC_PATH}/compsys/packages/pip3"
-
-echo "${section}Updating pip2 dependencies...${reset}"
-# The pip package listed in the pip requirements file needs to be installed
-# after the pip listed in the pip3 requirements file in order for pip2 to
-# be set as the default `pip`.
-sudo -H pip2 install --upgrade --requirement "${ROBOTIC_PATH}/compsys/packages/pip"
-
-if [[ $(sudo -H pip --version) != $(sudo -H pip2 --version) ]]; then
-  echo "Found mismatch in default pip. Correcting..."
-  # This will set the default pip to pip2 as expected
-  PIP_PATH=$(sudo which pip)
-  PIP2_PATH=$(sudo which pip2)
-  sudo rm -f ${PIP_PATH}
-  sudo ln -s ${PIP2_PATH} ${PIP_PATH}
-fi
 
 if [[ -d ${HOME}/.vim/bundle/Vundle.vim ]]; then
   echo "Updating vim plugins..."


### PR DESCRIPTION
If the pip package is updated/installed using `pip`, `pip` will refer
to `pip2`. If the pip package is updated/installed using `pip3`, `pip`
will refer to `pip3`. To remove this potential complication, use the pip
packages provided by Ubuntu. That way, `pip` will be `pip2`, and `pip3` will
be `pip3`.