### PR TITLE
Install numpy using apt instead of pip

### DIFF
--- a/packages/apt
+++ b/packages/apt
@@ -2,6 +2,10 @@ git
 wget
 python-pip
 python3-pip
+python-numpy
+python3-numpy
+python-pyqtgraph
+python3-pyqtgraph
 vim
 tmux
 tmuxinator
@@ -14,7 +18,7 @@ tree
 libv4l-dev
 python-pygame
 pyqt4-dev-tools
-software-properties-common 
+software-properties-common
 python-software-properties
 curl
 clang-format

--- a/packages/pip
+++ b/packages/pip
@@ -1,8 +1,6 @@
 pip
-numpy
 ipython<6.0
 pysensors
-pyqtgraph
 enum34
 catkin_tools
 catkin_lint

--- a/packages/pip3
+++ b/packages/pip3
@@ -1,5 +1,3 @@
 pip
-numpy
 ipython
-pyqtgraph
 virtualenvwrapper


### PR DESCRIPTION
Remove the need to compile numpy from source