### PR TITLE
Fix a specific version of the YAPF formatter

### DIFF
--- a/packages/pip
+++ b/packages/pip
@@ -4,5 +4,5 @@ enum34
 catkin_tools
 catkin_lint
 virtualenvwrapper
-yapf
+yapf==0.20.2
 futures


### PR DESCRIPTION
This will make sure everyone is running the same version of the YAPF formatter as the Jenkins server