### PR TITLE
Add vim-ros plugin

### DIFF
--- a/packages/apt
+++ b/packages/apt
@@ -6,7 +6,7 @@ python-numpy
 python3-numpy
 python-pyqtgraph
 python3-pyqtgraph
-vim
+vim-nox-py2
 tmux
 tmuxinator
 mosh

--- a/setup/config/vimrc
+++ b/setup/config/vimrc
@@ -49,6 +49,7 @@ if filereadable($HOME.'/.vim/bundle/Vundle.vim/autoload/vundle.vim')
   Plugin 'cocopon/lightline-hybrid.vim'
   Plugin 'fholgado/minibufexpl.vim'
   Plugin 'bronson/vim-trailing-whitespace'
+  Plugin 'taketwo/vim-ros'
 
   call vundle#end()
   filetype plugin indent on
@@ -131,6 +132,9 @@ let g:ctrlp_custom_ignore = '\v[\/]\.(git|hg|svn)$'
 " Lightline
 let g:lightline = {}
 let g:lightline.colorscheme = 'hybrid'
+
+" ROS
+let g:ros_build_system = 'catkin-tools'
 
 " Python specific settings
 autocmd Filetype python setlocal shiftwidth=4 softtabstop=4


### PR DESCRIPTION
This adds the very useful [vim-ros](https://github.com/taketwo/vim-ros) plugin. Unfortunately this requires `vim` to be compiled with Python 2 support since ROS is currently only Python 2-compatible. Hence, we need to install `vim-nox-py2` instead of `vim`.