### PR TITLE
Only run rosworkon if $ROBOT is defined

### DIFF
--- a/roboticrc
+++ b/roboticrc
@@ -96,7 +96,9 @@ function rosworkon {
 }
 
 # Set up default robot
-rosworkon ${ROBOT}
+if [[ -n "${ROBOT}" ]]; then
+  rosworkon "${ROBOT}"
+fi
 
 # Add compsys scripts to PYTHONPATH
 export PYTHONPATH="${PYTHONPATH}:${ROBOTIC_PATH}/compsys/scripts"


### PR DESCRIPTION
Some of our systems use `compsys` without a defined `$ROBOT` just to get some of the perks.