### PR TITLE
Update and clean vim plugins

### DIFF
--- a/update
+++ b/update
@@ -30,7 +30,7 @@ sudo -H pip3 install --upgrade --requirement "${ROBOTIC_PATH}/compsys/packages/p
 
 if [[ -d "${HOME}/.vim/bundle/Vundle.vim" ]]; then
   echo "Updating vim plugins..."
-  vim +PluginInstall +qall
+  vim +PluginInstall +PluginUpdate +PluginClean +qall
 fi
 
 # Update tools.sh repository.


### PR DESCRIPTION
Turns out we were just installing any missing plugins and not attempting to update them. This fixes that and also attempts to remove any plugins we may remove from the `.vimrc` at some point.