### PR TITLE
Fix cloning of robot repository

### DIFF
--- a/install
+++ b/install
@@ -236,15 +236,20 @@ if [[ ! -d "${gitdir}" ]]; then
   echo "Cloning ${ROBOT} git repository..."
 
   if [[ ${GIT_BRANCH} ]]; then
-    gitcmd="-b${GIT_BRANCH}"
+    git clone --recursive "git@github.com:${GIT_URL}" "${gitdir}" -b "${GIT_BRANCH}" || {
+      echo "${warning}GitHub SSH key doesn't seem to be set up properly${reset}"
+      echo "${warning}Falling back to HTTPS for now...${reset}"
+
+      git clone --recursive "https://github.com/${GIT_URL}" "${gitdir}" -b "${GIT_BRANCH}"
+    }
+  else
+    git clone --recursive "git@github.com:${GIT_URL}" "${gitdir}" || {
+      echo "${warning}GitHub SSH key doesn't seem to be set up properly${reset}"
+      echo "${warning}Falling back to HTTPS for now...${reset}"
+
+      git clone --recursive "https://github.com/${GIT_URL}" "${gitdir}"
+    }
   fi
-
-  git clone --recursive "git@github.com:${GIT_URL}" "${gitdir}" "${gitcmd}" || {
-    echo "${warning}GitHub SSH key doesn't seem to be set up properly${reset}"
-    echo "${warning}Falling back to HTTPS for now...${reset}"
-
-    git clone --recursive "https://github.com/${GIT_URL}" "${gitdir}" "${gitcmd}"
-  }
 fi
 
 if [[ -f /opt/ros/kinetic/setup.bash ]]; then

--- a/install
+++ b/install
@@ -236,11 +236,15 @@ if [[ ! -d "${gitdir}" ]]; then
   echo "Cloning ${ROBOT} git repository..."
 
   if [[ ${GIT_BRANCH} ]]; then
-    git clone --recursive "git@github.com:${GIT_URL}" "${gitdir}" -b "${GIT_BRANCH}" || {
+    git clone --recursive "git@github.com:${GIT_URL}" \
+              --branch "${GIT_BRANCH}" \
+              "${gitdir}" || {
       echo "${warning}GitHub SSH key doesn't seem to be set up properly${reset}"
       echo "${warning}Falling back to HTTPS for now...${reset}"
 
-      git clone --recursive "https://github.com/${GIT_URL}" "${gitdir}" -b "${GIT_BRANCH}"
+      git clone --recursive "https://github.com/${GIT_URL}" \
+                --branch "${GIT_BRANCH}" \
+                "${gitdir}"
     }
   else
     git clone --recursive "git@github.com:${GIT_URL}" "${gitdir}" || {


### PR DESCRIPTION
Fixes #134 git clone fails on install.

`${GIT_BRANCH}`can be empty and that could cause an extra argument (i.e. `""`) to be supplied to `git clone`.

There must be a better way to fix this without code repetition. I haven't figured out how.