### PR TITLE
Remove Python 3 packages

### DIFF
--- a/packages/apt
+++ b/packages/apt
@@ -1,11 +1,8 @@
 git
 wget
 python-pip
-python3-pip
 python-numpy
-python3-numpy
 python-pyqtgraph
-python3-pyqtgraph
 vim-nox-py2
 tmux
 tmuxinator

--- a/packages/pip3
+++ b/packages/pip3
@@ -1,2 +1,0 @@
-ipython
-virtualenvwrapper

--- a/update
+++ b/update
@@ -12,7 +12,8 @@ echo "${section}Updating apt dependencies...${reset}"
 sudo apt-get -q -y update
 # Filter out all comments in the apt requirements file using sed before
 # piping the contents of the requirements list into xargs.
-sed 's/#.*//' "${ROBOTIC_PATH}/compsys/packages/apt" | xargs sudo apt-get install -y
+sed 's/#.*//' "${ROBOTIC_PATH}/compsys/packages/apt" |
+  xargs sudo apt-get install -y
 
 # Suppress pip version checks.
 ROBOTICS_PIP_CONF="${ROBOTIC_PATH}/compsys/setup/config/pip.conf"
@@ -31,11 +32,8 @@ if [[ ! -f "${ROOT_PIP_CONF}" ]]; then
   sudo cp "${ROBOTICS_PIP_CONF}" "${ROOT_PIP_CONF}"
 fi
 
-echo "${section}Updating pip dependencies...${reset}"
-sudo -H pip install --upgrade --requirement "${ROBOTIC_PATH}/compsys/packages/pip"
-
-echo "${section}Updating pip3 dependencies...${reset}"
-sudo -H pip3 install --upgrade --requirement "${ROBOTIC_PATH}/compsys/packages/pip3"
+echo "${section}Updating Python 2 dependencies...${reset}"
+sudo -H pip2 install --upgrade --requirement "${ROBOTIC_PATH}/compsys/packages/pip"
 
 if [[ -f "${HOME}/.vim/autoload/plug.vim" ]]; then
   echo "${section}Updating vim plugins...${reset}"


### PR DESCRIPTION
We no longer use any of the Python 3 packages here, so it's safe to remove. This will avoid any more weird conflicting Python version bugs in the future. We really should only ever support one Python version at a time, and until ROS 2 comes out, we can't transition to Python 3.