### PR TITLE
Infer directory and ROBOTIC_PATH more robustly

### DIFF
--- a/install
+++ b/install
@@ -21,9 +21,13 @@ function onerr {
 }
 trap onerr ERR
 
-# Determine ROBOTIC_PATH
+# Infer repository root directory and ROBOTIC_PATH
 export ROBOTIC_PATH
-ROBOTIC_PATH=$(dirname "${PWD}")
+DIR="$(git rev-parse --show-toplevel 2> /dev/null)"
+ROBOTIC_PATH="$(dirname "${DIR}")"
+
+# Move into the repository
+cd "${DIR}"
 
 # Verify running on Ubuntu 16.04
 if [[ $(lsb_release -sc) != "xenial" ]]; then

--- a/setup/config/install
+++ b/setup/config/install
@@ -3,6 +3,10 @@
 # Set up shell, vim and tmux configuration files
 set -e
 
+# Infer repository root directory and ROBOTIC_PATH
+DIR="$(git rev-parse --show-toplevel 2> /dev/null)"
+ROBOTIC_PATH="$(dirname "${DIR}")"
+
 for rcfile in "${HOME}/.bashrc" "${HOME}/.zshrc"; do
   if [[ -f ${rcfile} ]]; then
     if ! grep -q "export ROBOTIC_PATH=" "${rcfile}"; then
@@ -11,7 +15,7 @@ for rcfile in "${HOME}/.bashrc" "${HOME}/.zshrc"; do
         -e "s@=\${IAMROBOT}@=${IAMROBOT}@" \
         -e "s@=\"\${ROBOTIC_PATH}\"@=\"${ROBOTIC_PATH//\//\/}\"@" \
         -e "s@\${rcfile}@~\\/${rcfile##*/}@" \
-        "${ROBOTIC_PATH}/compsys/setup/config/rc" >> "${rcfile}"
+        "${DIR}/setup/config/rc" >> "${rcfile}"
     fi
   fi
 done
@@ -23,7 +27,7 @@ for rcfile in "vimrc" "tmux.conf"; do
       rm -f "${HOME}/.${rcfile}"
     fi
     echo "Adding .${rcfile}..."
-    ln -s "${ROBOTIC_PATH}/compsys/setup/config/${rcfile}" "${HOME}/.${rcfile}"
+    ln -s "${DIR}/setup/config/${rcfile}" "${HOME}/.${rcfile}"
   fi
 done
 

--- a/setup/zsh/install
+++ b/setup/zsh/install
@@ -3,6 +3,9 @@
 # Install Zsh and set up Prezto
 set -e
 
+# Infer repository root directory
+DIR="$(git rev-parse --show-toplevel 2> /dev/null)"
+
 echo "Installing zsh..."
 sudo apt-get -y -qq install zsh
 
@@ -14,14 +17,14 @@ fi
 
 echo "Setting up .zshrc..."
 if [[ ! -f "${HOME}/.zshrc" ]]; then
-  cp "${ROBOTIC_PATH}/compsys/setup/zsh/zshrc" "${HOME}/.zshrc"
+  cp "${DIR}/setup/zsh/zshrc" "${HOME}/.zshrc"
 fi
 
 if [[ ! -f "${HOME}/.zpreztorc" ]]; then
   if [[ -L "${HOME}/.zpreztorc" ]]; then
     rm -f "${HOME}/.zpreztorc"
   fi
-  ln -s "${ROBOTIC_PATH}/compsys/setup/zsh/zpreztorc" "${HOME}/.zpreztorc"
+  ln -s "${DIR}/setup/zsh/zpreztorc" "${HOME}/.zpreztorc"
 fi
 
 echo "Setting up Fasd..."

--- a/update
+++ b/update
@@ -8,15 +8,18 @@ set -e
 section=$(tput bold; tput setaf 2)
 reset=$(tput sgr0)
 
+# Infer directory and ROBOTIC_PATH
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROBOTIC_PATH="$(dirname "${DIR}")"
+
 echo "${section}Updating apt dependencies...${reset}"
 sudo apt-get -q -y update
 # Filter out all comments in the apt requirements file using sed before
 # piping the contents of the requirements list into xargs.
-sed 's/#.*//' "${ROBOTIC_PATH}/compsys/packages/apt" |
-  xargs sudo apt-get install -y
+sed 's/#.*//' "${DIR}/packages/apt" | xargs sudo apt-get install -y
 
 # Suppress pip version checks.
-ROBOTICS_PIP_CONF="${ROBOTIC_PATH}/compsys/setup/config/pip.conf"
+ROBOTICS_PIP_CONF="${DIR}/setup/config/pip.conf"
 USER_PIP_DIR="${HOME}/.config/pip"
 USER_PIP_CONF="${USER_PIP_DIR}/pip.conf"
 if [[ ! -f "${USER_PIP_CONF}" ]]; then
@@ -33,7 +36,7 @@ if [[ ! -f "${ROOT_PIP_CONF}" ]]; then
 fi
 
 echo "${section}Updating Python 2 dependencies...${reset}"
-sudo -H pip2 install --upgrade --requirement "${ROBOTIC_PATH}/compsys/packages/pip"
+sudo -H pip2 install --upgrade --requirement "${DIR}/packages/pip"
 
 if [[ -f "${HOME}/.vim/autoload/plug.vim" ]]; then
   echo "${section}Updating vim plugins...${reset}"


### PR DESCRIPTION
This should allow people to install compsys without `cd`-ing into the repo, and even if their repo is called something other than `compsys`. This will also allow them to install only specific parts even if they don't have a `$ROBOTIC_PATH`