### PR TITLE
Fix cursor disappearing in zsh

### DIFF
--- a/setup/zsh/zpreztorc
+++ b/setup/zsh/zpreztorc
@@ -42,7 +42,6 @@ zstyle ':prezto:module:syntax-highlighting' highlighters \
   'brackets' \
   'pattern' \
   'line' \
-  'cursor' \
   'root'
 
 # Case sensitivity


### PR DESCRIPTION
The cursor disappears when backtracking the cursor in zsh when this is enabled due to a bug in `zsh-syntax-highlighting`