### PR TITLE
Remove catkin_tools from pip

### DIFF
--- a/packages/pip
+++ b/packages/pip
@@ -1,6 +1,5 @@
 ipython<6.0  # Interactive python interpreter
 pysensors  # lm-sensors bindings
-catkin_tools  # ROS build tool
 catkin_lint==1.4.20  # ROS package linter
 pipenv  # Python virtual environment tool
 yapf==0.20.2  # Python formatter


### PR DESCRIPTION
`catkin_tools` is now included in `ros-<distro>-desktop` and installing it via pip is not recommanded.

https://answers.ros.org/question/301702/ros-kinetic-importerror-no-module-named-terminal_color/?answer=301712#post-id-301712